### PR TITLE
Fix: Parse statements correctly when there's a comment

### DIFF
--- a/crates/loxide_parser/snapshots/parser/snapshots-inputs/many_statements.lox
+++ b/crates/loxide_parser/snapshots/parser/snapshots-inputs/many_statements.lox
@@ -6,3 +6,5 @@
 true ;
 false;
 nil;
+2 >= 1; // comments
+2 > 1 ; // comments

--- a/crates/loxide_parser/snapshots/parser/snapshots-outputs/loxide_parser__parser__tests__many_statements.snap
+++ b/crates/loxide_parser/snapshots/parser/snapshots-outputs/loxide_parser__parser__tests__many_statements.snap
@@ -75,6 +75,52 @@ expression: results
                 ),
             },
         ),
+        Expression(
+            Expr {
+                kind: Binary(
+                    BinaryExpr {
+                        lhs: Expr {
+                            kind: Literal(
+                                Number(
+                                    2.0,
+                                ),
+                            ),
+                        },
+                        rhs: Expr {
+                            kind: Literal(
+                                Number(
+                                    1.0,
+                                ),
+                            ),
+                        },
+                        operator: GreaterEqual,
+                    },
+                ),
+            },
+        ),
+        Expression(
+            Expr {
+                kind: Binary(
+                    BinaryExpr {
+                        lhs: Expr {
+                            kind: Literal(
+                                Number(
+                                    2.0,
+                                ),
+                            ),
+                        },
+                        rhs: Expr {
+                            kind: Literal(
+                                Number(
+                                    1.0,
+                                ),
+                            ),
+                        },
+                        operator: Greater,
+                    },
+                ),
+            },
+        ),
     ],
     [
         Expect(

--- a/crates/loxide_parser/src/parser.rs
+++ b/crates/loxide_parser/src/parser.rs
@@ -83,6 +83,7 @@ impl<'src> Parser<'src> {
     fn expression_stmt(&mut self) -> Result<Stmt<'src>, SyntaxError> {
         let expr = self.expression()?;
         self.consume(TokenType::Semicolon)?;
+        self.consume_if(TokenType::Comment);
         Ok(Stmt::Expression(expr))
     }
 


### PR DESCRIPTION
Close #6 