### PR TITLE
Fix: fix unexpected parse error when there are comments in `block stmt`

### DIFF
--- a/crates/loxide_parser/snapshots/regression/snapshots-inputs/issue15.lox
+++ b/crates/loxide_parser/snapshots/regression/snapshots-inputs/issue15.lox
@@ -1,0 +1,3 @@
+{
+    var a = 1; // comments
+}

--- a/crates/loxide_parser/snapshots/regression/snapshots-outputs/issue15.snap
+++ b/crates/loxide_parser/snapshots/regression/snapshots-outputs/issue15.snap
@@ -1,0 +1,28 @@
+---
+source: crates/loxide_parser/tests/regression/issue15.rs
+expression: result
+input_file: crates/loxide_parser/snapshots/regression/snapshots-inputs/issue15.lox
+---
+(
+    [
+        Block(
+            [
+                VarDeclaration(
+                    Variable {
+                        name: "a",
+                    },
+                    Some(
+                        Expr {
+                            kind: Literal(
+                                Number(
+                                    1.0,
+                                ),
+                            ),
+                        },
+                    ),
+                ),
+            ],
+        ),
+    ],
+    [],
+)

--- a/crates/loxide_parser/src/parser.rs
+++ b/crates/loxide_parser/src/parser.rs
@@ -129,7 +129,12 @@ impl<'src> Parser<'src> {
         loop {
             match self.peek_type()? {
                 TokenType::RightBrace => break,
-                _ => stmts.push(self.declaration()?),
+                _ => {
+                    stmts.push(self.declaration()?);
+                    while self.consume_if(TokenType::Comment) {
+                        continue;
+                    }
+                }
             }
         }
         self.consume(TokenType::RightBrace)?;

--- a/crates/loxide_parser/tests/regression/issue15.rs
+++ b/crates/loxide_parser/tests/regression/issue15.rs
@@ -1,0 +1,11 @@
+use loxide_macros::src;
+
+#[test]
+fn issue15() {
+    regression!("issue15.lox", |path| {
+        let src = src!(path);
+        let mut parser = ::loxide_parser::parser::Parser::new(&src);
+        let result = parser.parse();
+        insta::assert_debug_snapshot!(result)
+    });
+}


### PR DESCRIPTION
Close #15 