### PR TITLE
Feat: support pin the test to a path

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,5 +8,6 @@ loxide_interpreter = { version = "0.1.0", path = "crates/loxide_interpreter" }
 # publish = false
 loxide_macros = { version = "0.1.0", path = "crates/loxide_macros" }
 loxide_testsuite = { version = "0.1.0", path = "crates/loxide_testsuite" }
+loxide_testsuite_macros = { version = "0.1.0", path = "crates/loxide_testsuite_macros" }
 insta = { version = "1.31.0", features = ["glob"] }
 thiserror = { version = "1.0.44" }

--- a/crates/loxide_testsuite/Cargo.toml
+++ b/crates/loxide_testsuite/Cargo.toml
@@ -8,3 +8,4 @@ edition = "2021"
 [dependencies]
 insta = { workspace = true, features = ["glob"] }
 once_cell = "1.18.0"
+loxide_testsuite_macros = { workspace = true }

--- a/crates/loxide_testsuite/src/lib.rs
+++ b/crates/loxide_testsuite/src/lib.rs
@@ -1,6 +1,8 @@
 mod macros;
 mod probe;
 mod unittest;
+// re-export the proc-macros
+pub use loxide_testsuite_macros::*;
 
 #[doc(hidden)]
 pub mod _macro_support {

--- a/crates/loxide_testsuite/src/macros.rs
+++ b/crates/loxide_testsuite/src/macros.rs
@@ -49,4 +49,16 @@ macro_rules! unittest {
             );
         }
     };
+
+    ($pin_to:expr, $name:ident, $closure:expr) => {
+        #[test]
+        fn $name() {
+            $crate::_macro_support::source_exec(
+                concat!(stringify!($name), ".lox"),
+                $pin_to,
+                ::std::env!("CARGO_MANIFEST_DIR"),
+                $closure,
+            );
+        }
+    };
 }

--- a/crates/loxide_testsuite_macros/Cargo.toml
+++ b/crates/loxide_testsuite_macros/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "loxide_testsuite_macros"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+[lib]
+proc-macro = true
+
+[dependencies]
+proc-macro2 = "1.0.66"
+quote = "1.0.33"
+syn = { version = "2.0.29", features = ["full", "extra-traits"] }

--- a/crates/loxide_testsuite_macros/src/lib.rs
+++ b/crates/loxide_testsuite_macros/src/lib.rs
@@ -1,0 +1,33 @@
+use proc_macro::TokenStream;
+use quote::quote;
+use syn::{parse_macro_input, Item, ItemMod, Lit, LitStr};
+
+#[proc_macro_attribute]
+pub fn pin(attr: TokenStream, input: TokenStream) -> TokenStream {
+    let mut input = parse_macro_input!(input as ItemMod);
+    let attr = parse_macro_input!(attr as Lit);
+    let attr = if let Lit::Str(s) = attr {
+        let changed = format!("dummy::{}", s.value());
+        Lit::Str(LitStr::new(&changed, s.span()))
+    } else {
+        panic!("Expected String Literal")
+    };
+
+    if let Some(ref mut items) = input.content {
+        for item in &mut items.1 {
+            if let Item::Macro(ref mut macro_item) = item {
+                let mac = &mut macro_item.mac;
+                let tokens = mac.tokens.clone();
+                mac.tokens = quote! {
+                    #attr,
+                    #tokens
+                };
+            }
+        }
+    }
+
+    let output = quote! {
+        #input
+    };
+    output.into()
+}


### PR DESCRIPTION
The path of snapshot input and output is determined by the module path
https://github.com/Devin-Yeung/loxide/blob/747d006f3ac478bb85739b8da8e66b4c53cc1d21/crates/loxide_testsuite/src/macros.rs#L44-L49
if we change the module of that tests in, all the test will break, we need to refactor all the tests.
So this PR introduce a attribute macro, which can _pin_ the path of the test
```rust
// assume the current module path is crates::foo::bar
// the test will be redirect to CARGO_MANIFEST_DIR/foo/bar
mod tests {
// ...
}
```
we can redirect the output to a fixed path `CARGO_MANIFEST_DIR/baz/foo` by:
```rust
#[loxide_testsuite::pin("baz::foo")]
mod tests {
// ...
}
```