### PR TITLE
Fix: fix a bunch of clippy warnings

### DIFF
--- a/crates/loxide_interpreter/src/eval.rs
+++ b/crates/loxide_interpreter/src/eval.rs
@@ -143,14 +143,14 @@ impl<'src> Evaluable for Option<Expr<'src>> {
 
 impl<'src> Evaluable for Expr<'src> {
     fn eval(&self, env: &mut Environment) -> Result<Value, RuntimeError> {
-        return match &self.kind {
+        match &self.kind {
             ExprKind::Literal(l) => l.eval(env),
             ExprKind::Unary(u) => u.eval(env),
             ExprKind::Binary(b) => b.eval(env),
             ExprKind::Grouped(g) => g.eval(env),
             ExprKind::Variable(v) => v.eval(env),
             ExprKind::Assign(a) => a.eval(env),
-        };
+        }
     }
 }
 
@@ -219,7 +219,7 @@ impl<'src> Evaluable for BinaryExpr<'src> {
 impl<'src> Evaluable for UnaryExpr<'src> {
     fn eval(&self, env: &mut Environment) -> Result<Value, RuntimeError> {
         let value = self.expr.eval(env)?;
-        return match self.operator {
+        match self.operator {
             UnaryOperator::Minus => {
                 let num = inner_or!(value, number, RuntimeError::InvalidUnaryOperand("number"))?;
                 Ok(Value::Number(-num))
@@ -228,7 +228,7 @@ impl<'src> Evaluable for UnaryExpr<'src> {
                 let bool = inner_or!(value, boolean, RuntimeError::InvalidUnaryOperand("boolean"))?;
                 Ok(Value::Boolean(!bool))
             }
-        };
+        }
     }
 }
 
@@ -240,7 +240,7 @@ impl<'src> Evaluable for GroupedExpr<'src> {
 
 impl<'src> Evaluable for Variable<'src> {
     fn eval(&self, env: &mut Environment) -> Result<Value, RuntimeError> {
-        env.get(self.name).map(|v| v.to_owned())
+        env.get(self.name)
     }
 }
 
@@ -272,56 +272,56 @@ mod tests {
     }
 
     unittest!(literal, |src| {
-        let results = eval(&src);
+        let results = eval(src);
         insta::assert_debug_snapshot!(results);
     });
 
     unittest!(valid_unary, |src| {
-        let results = eval(&src);
+        let results = eval(src);
         insta::assert_debug_snapshot!(results);
     });
 
     unittest!(invalid_unary, |src| {
-        let results: Vec<_> = src.split('\n').into_iter().map(|src| eval(&src)).collect();
+        let results: Vec<_> = src.split('\n').map(eval).collect();
         insta::assert_debug_snapshot!(results);
     });
 
     unittest!(valid_binary, |src| {
-        let results = eval(&src);
+        let results = eval(src);
         insta::assert_debug_snapshot!(results);
     });
 
     unittest!(variable, |src| {
-        let results: Vec<_> = eval(&src);
+        let results: Vec<_> = eval(src);
         insta::assert_debug_snapshot!(results);
     });
 
     unittest!(block_stmt, |src| {
         register!();
-        eval(&src);
+        eval(src);
         insta::assert_debug_snapshot!(footprints!());
     });
 
     unittest!(if_stmt, |src| {
         register!();
-        eval(&src);
+        eval(src);
         insta::assert_debug_snapshot!(footprints!());
     });
 
     unittest!(while_stmt, |src| {
         register!();
-        eval(&src);
+        eval(src);
         insta::assert_debug_snapshot!(footprints!());
     });
 
     unittest!(for_stmt, |src| {
         register!();
-        eval(&src);
+        eval(src);
         insta::assert_debug_snapshot!(footprints!());
     });
 
     unittest!(for_stmt_expect_bool, |src| {
-        let results: Vec<_> = eval(&src);
+        let results: Vec<_> = eval(src);
         insta::assert_debug_snapshot!(results);
     });
 }

--- a/crates/loxide_parser/src/parser.rs
+++ b/crates/loxide_parser/src/parser.rs
@@ -66,15 +66,15 @@ impl<'src> Parser<'src> {
     fn peek_type(&mut self) -> Result<TokenType<'src>, SyntaxError> {
         match self.tokens.peek() {
             None => Ok(TokenType::EOF),
-            Some(&Ok(ref token)) => Ok(token.ty.clone()),
-            Some(&Err(ref err)) => Err(err.clone()),
+            Some(Ok(token)) => Ok(token.ty.clone()),
+            Some(Err(err)) => Err(*err),
         }
     }
 
     fn advance(&mut self) -> Result<Token<'src>, SyntaxError> {
         self.tokens
             .next()
-            .unwrap_or_else(|| Err(SyntaxError::UnexpectedEOF))
+            .unwrap_or(Err(SyntaxError::UnexpectedEOF))
     }
 
     /// parse declaration according to following rules:
@@ -567,37 +567,37 @@ mod tests {
     });
 
     unittest!(many_statements, |src| {
-        let mut parser = Parser::new(&src);
+        let mut parser = Parser::new(src);
         let results = parser.parse();
         insta::assert_debug_snapshot!(results);
     });
 
     unittest!(declarations, |src| {
-        let mut parser = Parser::new(&src);
+        let mut parser = Parser::new(src);
         let results = parser.parse();
         insta::assert_debug_snapshot!(results);
     });
 
     unittest!(block_statement, |src| {
-        let mut parser = Parser::new(&src);
+        let mut parser = Parser::new(src);
         let results = parser.parse();
         insta::assert_debug_snapshot!(results);
     });
 
     unittest!(if_statement, |src| {
-        let mut parser = Parser::new(&src);
+        let mut parser = Parser::new(src);
         let results = parser.parse();
         insta::assert_debug_snapshot!(results);
     });
 
     unittest!(while_statement, |src| {
-        let mut parser = Parser::new(&src);
+        let mut parser = Parser::new(src);
         let results = parser.parse();
         insta::assert_debug_snapshot!(results);
     });
 
     unittest!(for_statement, |src| {
-        let mut parser = Parser::new(&src);
+        let mut parser = Parser::new(src);
         let results = parser.parse();
         insta::assert_debug_snapshot!(results);
     });

--- a/crates/loxide_parser/src/prophetic.rs
+++ b/crates/loxide_parser/src/prophetic.rs
@@ -22,7 +22,7 @@ where
     }
 
     pub fn peek(&self) -> Option<I::Item> {
-        if self.buffer.len() < 1 {
+        if self.buffer.is_empty() {
             unreachable!()
         }
         self.buffer[0]

--- a/crates/loxide_parser/src/scanner.rs
+++ b/crates/loxide_parser/src/scanner.rs
@@ -28,12 +28,12 @@ impl<'src> Scanner<'src> {
     }
 
     pub fn consume_if(&mut self, expected: char) -> bool {
-        return if self.peek() == Some(expected) {
+        if self.peek() == Some(expected) {
             self.advance();
             true
         } else {
             false
-        };
+        }
     }
 
     fn peek(&mut self) -> Option<char> {
@@ -61,7 +61,7 @@ impl<'src> Scanner<'src> {
     }
 
     pub fn is_at_end(&self) -> bool {
-        self.prophet.peek() == None
+        self.prophet.peek().is_none()
     }
 
     fn eat_whitespace(&mut self) {
@@ -118,7 +118,7 @@ impl<'src> Scanner<'src> {
                 false => TokenType::Slash,
             },
             Some('\"') => self.string()?,
-            Some(c) if c.is_digit(10) => self.number()?,
+            Some(c) if c.is_ascii_digit() => self.number()?,
             Some(c) if c.is_ascii_alphabetic() || c == '_' => self.identifier(),
             None => TokenType::EOF,
             _ => return Err(SyntaxError::UnexpectedChar(self.current.line)),
@@ -163,13 +163,13 @@ impl<'src> Scanner<'src> {
         while let Some(c) = self.peek() {
             match c {
                 '.' => {
-                    if self.peek_next().map_or(false, |c| c.is_digit(10)) {
+                    if self.peek_next().map_or(false, |c| c.is_ascii_digit()) {
                         self.advance()
                     } else {
                         return Err(SyntaxError::InvalidNumber);
                     }
                 }
-                c if c.is_digit(10) => self.advance(),
+                c if c.is_ascii_digit() => self.advance(),
                 _ => break,
             };
         }
@@ -192,7 +192,7 @@ impl<'src> Scanner<'src> {
             &self.src[self.consumed..self.consumed + self.current.end - self.current.start];
         content
             .parse::<Keyword>()
-            .map(|k| TokenType::Keyword(k))
+            .map(TokenType::Keyword)
             .unwrap_or(TokenType::Identifier)
     }
 }

--- a/crates/loxide_testsuite/src/probe.rs
+++ b/crates/loxide_testsuite/src/probe.rs
@@ -15,13 +15,13 @@ pub struct FootPrint(String);
 
 impl PartialEq<FootPrint> for &str {
     fn eq(&self, other: &FootPrint) -> bool {
-        return self.eq(&other.0);
+        self.eq(&other.0)
     }
 }
 
 impl PartialEq<&str> for FootPrint {
     fn eq(&self, other: &&str) -> bool {
-        return self.0.eq(other);
+        self.0.eq(other)
     }
 }
 

--- a/crates/loxide_testsuite/src/unittest/tester.rs
+++ b/crates/loxide_testsuite/src/unittest/tester.rs
@@ -88,11 +88,10 @@ impl<P: AsRef<Path>, S: AsRef<str>> TesterBuilder<P, S> {
     }
 
     fn build(self) -> Tester {
-        let tester = Tester {
+        Tester {
             source_path: self.source_path(),
             snapshot_path: self.snapshot_path(),
-        };
-        tester
+        }
     }
 }
 
@@ -102,7 +101,7 @@ pub fn source_exec<F: FnMut(&str)>(
     cargo_manifest_dir: &str,
     f: F,
 ) {
-    TesterBuilder::new(source_name, module_path, cargo_manifest_dir.into())
+    TesterBuilder::new(source_name, module_path, cargo_manifest_dir)
         .build()
         .source_exec(f);
 }


### PR DESCRIPTION
Fix some clippy warnings by `cargo clippy --fix`